### PR TITLE
Convert rogerprz/pipeline-tools to Github Actions

### DIFF
--- a/.github/workflows/pipeline-tools.yml
+++ b/.github/workflows/pipeline-tools.yml
@@ -1,0 +1,10 @@
+name: rogerprz/pipeline-tools
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+    - name: sh
+      shell: bash
+      run: mvn -DskipTests clean site install


### PR DESCRIPTION
Pipeline migrated from [Jenkins](https://jenkout.westus2.cloudapp.azure.com/job/rogerprz/job/pipeline-tools) :tada:

## Manual steps

Perform the follow steps to complete the migration:
- [ ] Ensure build tool is available: `maven`